### PR TITLE
Clean up peerDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,12 +23,8 @@
     "graphql"
   ],
   "peerDependencies": {
-    "@apollo/gateway": "^0.41.0",
-    "@nestjs/common": "^8.0.6",
-    "@nestjs/core": "^8.0.6",
-    "@nestjs/graphql": "^9.0.4",
-    "graphql": "^15.5.3",
-    "reflect-metadata": "^0.1.12"
+    "@nestjs/common": "^8.0.0 || ^9.0.0",
+    "@nestjs/core": "^8.0.0 || ^9.0.0"
   },
   "dependencies": {
     "dataloader": "^2.0.0"


### PR DESCRIPTION
Update nestjs dependencies to allow 9.x; Remove other peer dependencies

The other dependencies are either imported by the requirements on nestjs, or are optional in general: i.e. you arguably don't NEED to use dataloader with graphql/apollo.

Ultimately, the requirement on these peer deps was out of date, causing npm install issues with npm v8